### PR TITLE
fritzcollectd: Adapt to fritzconnection 0.8

### DIFF
--- a/fritzcollectd/__init__.py
+++ b/fritzcollectd/__init__.py
@@ -55,20 +55,14 @@ class FritzCollectd(object):
     # dict: {(service, service_action):
     #           {action_argument: (value_instance, value_type)}}
     SERVICE_ACTIONS = OrderedDict([
-        # Returns an empty dict if called on the authenticated connection.
-        (ServiceAction('WANIPConnection:1', 'GetStatusInfo'),
+        (ServiceAction('WANIPConn:1', 'GetStatusInfo'),
          {'NewConnectionStatus': Value('constatus', 'gauge'),
           'NewUptime': Value('uptime', 'uptime')}),
-        # Returns maximal possible bit rates on the line if called on the
-        # authenticated connection.
-        (ServiceAction('WANCommonInterfaceConfig:1',
-                       'GetCommonLinkProperties'),
+        (ServiceAction('WANCommonIFC:1', 'GetCommonLinkProperties'),
          {'NewPhysicalLinkStatus': Value('dslstatus', 'gauge'),
           'NewLayer1DownstreamMaxBitRate': Value('downstreammax', 'bitrate'),
           'NewLayer1UpstreamMaxBitRate': Value('upstreammax', 'bitrate')}),
-        # Throws 'ActionError: Unknown Action: GetAddonInfos' on the
-        # authenticated connection.
-        (ServiceAction('WANCommonInterfaceConfig:1', 'GetAddonInfos'),
+        (ServiceAction('WANCommonIFC:1', 'GetAddonInfos'),
          {'NewByteSendRate': Value('sendrate', 'bitrate'),
           'NewByteReceiveRate': Value('receiverate', 'bitrate'),
           'NewTotalBytesSent': Value('totalbytessent', 'bytes'),
@@ -149,7 +143,7 @@ class FritzCollectd(object):
             raise IOError("fritzcollectd: Failed to connect to %s" %
                           self._fritz_address)
 
-        if not self._fc.call_action('WANIPConnection:1', 'GetStatusInfo'):
+        if not self._fc.call_action('WANIPConn:1', 'GetStatusInfo'):
             self._fc = None
             raise IOError("fritzcollectd: Statusinformation via UPnP is "
                           "not enabled")
@@ -174,7 +168,7 @@ class FritzCollectd(object):
 
                 self._filter_service_actions(self.SERVICE_ACTIONS_AUTH,
                                              self._fc_auth.actionnames)
-            except XMLSyntaxError:
+            except fritzconnection.AuthorizationError:
                 self._fc = None
                 self._fc_auth = None
                 raise IOError("fritzcollectd: Incorrect password or "

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-fritzconnection>=0.6.0,<0.8.0
+fritzconnection>=0.8.0
 pbr

--- a/tests/test_fritzcollectd.py
+++ b/tests/test_fritzcollectd.py
@@ -37,6 +37,8 @@ import pytest
 
 from lxml.etree import XMLSyntaxError  # pylint: disable=no-name-in-module
 
+import fritzconnection
+
 
 class CollectdMock(object):
     """ Mocks the collectd object that is injected into plugins when
@@ -142,14 +144,16 @@ class FritzConnectionMock(object):  # pylint: disable=too-few-public-methods
         to support the normal (good case) tests. """
 
     FRITZBOX_DATA = {
-        ('WANIPConnection:1', 'GetStatusInfo'):
+        ('WANIPConn:1', 'GetStatusInfo'):
         {'NewConnectionStatus': 'Connected',
          'NewUptime': 35307},
-        ('WANCommonInterfaceConfig:1', 'GetCommonLinkProperties'):
+        ('WANIPConnection:1', 'GetStatusInfo'):
+        {},
+        ('WANCommonIFC:1', 'GetCommonLinkProperties'):
         {'NewLayer1DownstreamMaxBitRate': 10087000,
          'NewLayer1UpstreamMaxBitRate': 2105000,
          'NewPhysicalLinkStatus': 'Up'},
-        ('WANCommonInterfaceConfig:1', 'GetAddonInfos'):
+        ('WANCommonIFC:1', 'GetAddonInfos'):
         {'NewByteSendRate': 3438,
          'NewByteReceiveRate': 67649,
          'NewTotalBytesSent': 1712232562,
@@ -323,7 +327,8 @@ def test_incorrect_password(fc_class_mock):
     """ Simulate an incorrect password on router. """
     fc_mock = FritzConnectionMock()
     fc_class_mock.return_value = fc_mock
-    fc_mock.call_action.side_effect = [{0}, XMLSyntaxError(0, 0, 0, 0)]
+    fc_mock.call_action.side_effect = [
+        {0}, fritzconnection.AuthorizationError(0, 0, 0, 0)]
     with pytest.raises(IOError):
         MOCK.process(CollectdConfig({'Password': 'incorrect'}))
 


### PR DESCRIPTION
The fritzconnection library has changed the way the services are named.
Calls that work without authentication now use corrcet short names such
as WANIPConn:1 or WANCommonIFC:1. This fixes the root cause of
requiring two connections to the fritzbox in fritzcollectd (see the
comments in this commit's diff).

Changing to a single connection will be done in a separate commit.

See: https://bitbucket.org/kbr/fritzconnection/issues/37/unknown-service-wancommoninterfaceconfig-1
Fixes: https://github.com/fetzerch/fritzcollectd/issues/31